### PR TITLE
pass --bvals to bse.py script

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -841,6 +841,7 @@ The script that does the above is:
         nifti_fs2dwi [SWITCHES] [SUBCOMMAND [SWITCHES]] 
     
     Switches:
+        --bvals VALUE:ExistingFile                    bvals file of the DWI; required
         -d, --debug                                   Debug mode, saves intermediate transforms to out/fs2dwi-debug-<pid>
         --dwi VALUE:ExistingFile                      target DWI; required
         --dwimask VALUE:ExistingFile                  DWI mask; required

--- a/scripts/fs2dwi.py
+++ b/scripts/fs2dwi.py
@@ -150,7 +150,7 @@ class Direct(cli.Application):
                           '--regheader', wmparcmgz, '--o', wmparc)
 
             print('Extracting B0 from DWI and masking it')
-            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-i', self.parent.dwi, '--bvals', self.bvals_file,
+            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-i', self.parent.dwi, '--bvals', self.parent.bvals_file,
                                    '-m', self.parent.dwimask, '-o', b0masked]), shell= True)
             print('Made masked B0')
 
@@ -242,7 +242,8 @@ class WithT2(cli.Application):
                           '--regheader', wmparcmgz, '--o', wmparc)
 
             print('Extracting B0 from DWI and masking it')
-            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-i', self.parent.dwi, '-m', self.parent.dwimask, '-o', b0masked]), shell= True)
+            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-i', self.parent.dwi, '--bvals', self.parent.bvals_file,
+                                   '-m', self.parent.dwimask, '-o', b0masked]), shell= True)
             print('Made masked B0')
 
 

--- a/scripts/fs2dwi.py
+++ b/scripts/fs2dwi.py
@@ -67,6 +67,12 @@ class FsToDwi(cli.Application):
         cli.ExistingFile,
         help='target DWI',
         mandatory=True)
+    
+    bvals_file= cli.SwitchAttr(
+        ['--bvals'],
+        cli.ExistingFile,
+        help='bvals file of the DWI',
+        mandatory=True)
 
     dwimask = cli.SwitchAttr(
         ['--dwimask'],
@@ -144,7 +150,8 @@ class Direct(cli.Application):
                           '--regheader', wmparcmgz, '--o', wmparc)
 
             print('Extracting B0 from DWI and masking it')
-            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-i', self.parent.dwi, '-m', self.parent.dwimask, '-o', b0masked]), shell= True)
+            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-i', self.parent.dwi, '--bvals', self.bvals_file,
+                                   '-m', self.parent.dwimask, '-o', b0masked]), shell= True)
             print('Made masked B0')
 
 

--- a/scripts/pnl_eddy.py
+++ b/scripts/pnl_eddy.py
@@ -63,7 +63,8 @@ class App(cli.Application):
             fslsplit[self.dwi] & FG
 
             logging.info('Extract the B0')
-            check_call((' ').join([pjoin(FILEDIR,'bse.py'), '-i', self.dwi._path, '-o', 'b0.nii.gz']), shell= True)
+            check_call((' ').join([pjoin(FILEDIR,'bse.py'), '-i', self.dwi._path, 
+                                   '--bvals', self.bvalFile, '-o', 'b0.nii.gz']), shell= True)
 
             logging.info('Register each volume to the B0')
             vols = sorted(tmpdir // (dicePrefix + '*.nii.gz'))

--- a/scripts/pnl_epi.py
+++ b/scripts/pnl_epi.py
@@ -90,7 +90,8 @@ class App(cli.Application):
             affine= tmpdir / 't2tobse_rigid0GenericAffine.mat'
 
             logging.info('1. Extract B0 and and mask it')
-            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-m', self.dwimask, '-i', self.dwi, '-o', bse]), shell=True)
+            check_call((' ').join([pjoin(FILEDIR, 'bse.py'), '-m', self.dwimask, '-i', self.dwi, 
+                                   '--bvals', self.bvals_file, '-o', bse]), shell=True)
 
             logging.info('2. Mask the T2')
             fslmaths(self.t2mask, '-mul', self.t2, t2masked)


### PR DESCRIPTION
so far the assumption has been --bvals have the same suffix as that of --dwi
this change gives the user more flexibility w.r.t the above
should be useful for downstream analysis from eddy_openmp
that produces --bvals/--bvecs with different suffix

cc @sbouix @kniajans