### PR TITLE
Remove custom TemporaryDirectory and psutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pyyaml
 matplotlib
 luigi
 sqlalchemy
-statsmodels
 scikit-image
 git+https://github.com/mhe/pynrrd.git
 git+https://github.com/pnlbwh/conversion.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,10 @@ pandas
 nibabel
 nilearn
 pyyaml
-psutil
 matplotlib
 luigi
 sqlalchemy
 statsmodels
 scikit-image
-git+https://github.com/dstrohl/Python_log_indenter.git
 git+https://github.com/mhe/pynrrd.git
 git+https://github.com/pnlbwh/conversion.git

--- a/scripts/DWIqc/dwi_quality_batch.py
+++ b/scripts/DWIqc/dwi_quality_batch.py
@@ -5,7 +5,6 @@ from plumbum import cli
 from os.path import dirname, join, basename, abspath, isdir
 from os import mkdir
 from shutil import rmtree
-import psutil
 import multiprocessing
 import pandas as pd
 import nibabel as nib
@@ -123,7 +122,7 @@ class quality_batch(cli.Application):
         imgs, masks = read_imgs_masks(self.imagelist)
 
         if int(self.N_proc)==-1:
-            self.N_proc= psutil.cpu_count()
+            self.N_proc= multiprocessing.cpu_count()
 
         pool= multiprocessing.Pool(int(self.N_proc))
         for imgPath, maskPath in zip(imgs, masks):

--- a/scripts/fs2dwi.py
+++ b/scripts/fs2dwi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from plumbum import local, cli
-import sys, os, tempfile, psutil, warnings
+import sys, os, tempfile, warnings
 from plumbum.cmd import ResampleImageBySpacing, antsApplyTransforms, ImageMath
 from subprocess import check_call
 

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -3,8 +3,7 @@ __version__ = '0.1.3'
 from os.path import abspath, dirname, join as pjoin, isfile
 import os
 from plumbum import local
-from tempfile import mkdtemp
-import weakref, shutil
+from tempfile import TemporaryDirectory
 
 FILEDIR= abspath(dirname(__file__))
 LIBDIR= dirname(FILEDIR)
@@ -19,16 +18,13 @@ N_PROC = '4'
 REPOL_BSHELL_GREATER= 550
 QC_POLL= 30 # seconds
 
-TMPDIR= local.path(os.getenv('PNLPIPE_TMPDIR','/tmp/'))
-# TMPDIR= local.path(os.getenv('PNLPIPE_TMPDIR',pjoin(os.environ['HOME'],'tmp'))
+
+TMPDIR= local.path(os.getenv('PNLPIPE_TMPDIR',pjoin(os.environ['HOME'],'tmp')))
 if not TMPDIR.exists():
     TMPDIR.mkdir()
 
 
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=FutureWarning)
-    from nibabel import load as load_nifti, Nifti1Image
+from nibabel import load as load_nifti, Nifti1Image
 
 
 def save_nifti(fname, data, affine, hdr=None):
@@ -46,72 +42,6 @@ def save_nifti(fname, data, affine, hdr=None):
 def logfmt(scriptname):
     return '%(asctime)s ' + scriptname + ' %(levelname)s  %(message)s'
 
-import psutil
-N_CPU= psutil.cpu_count()
-
-
-# the following context manager is copied from https://github.com/python/cpython/blob/master/Lib/tempfile.py#L762
-class TemporaryDirectory(object):
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
-    example:
-        with TemporaryDirectory() as tmpdir:
-            ...
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
-    """
-
-    def __init__(self, suffix=None, prefix=None, dir=TMPDIR):
-        self.name = mkdtemp(suffix, prefix, dir)
-        self._finalizer = weakref.finalize(
-            self, self._cleanup, self.name,
-            warn_message="Implicitly cleaning up {!r}".format(self))
-
-    @classmethod
-    def _rmtree(cls, name):
-        def onerror(func, path, exc_info):
-            if issubclass(exc_info[0], PermissionError):
-                def resetperms(path):
-                    try:
-                        os.chflags(path, 0)
-                    except AttributeError:
-                        pass
-                    os.chmod(path, 0o700)
-
-                try:
-                    if path != name:
-                        resetperms(os.path.dirname(path))
-                    resetperms(path)
-
-                    try:
-                        os.unlink(path)
-                    # PermissionError is raised on FreeBSD for directories
-                    except (IsADirectoryError, PermissionError):
-                        cls._rmtree(path)
-                except FileNotFoundError:
-                    pass
-            elif issubclass(exc_info[0], FileNotFoundError):
-                pass
-            else:
-                exit(1)
-
-        shutil.rmtree(name, onerror=onerror)
-
-    @classmethod
-    def _cleanup(cls, name, warn_message):
-        cls._rmtree(name)
-        warnings.warn(warn_message, ResourceWarning)
-
-    def __repr__(self):
-        return "<{} {!r}>".format(self.__class__.__name__, self.name)
-
-    def __enter__(self):
-        return self.name
-
-    def __exit__(self, exc, value, tb):
-        self.cleanup()
-
-    def cleanup(self):
-        if self._finalizer.detach():
-            self._rmtree(self.name)
+from multiprocessing import cpu_count
+N_CPU= cpu_count()
 


### PR DESCRIPTION
- For a long time, we had dependency on a custom `TemporaryDirectory` definition. Now `tempfile` already supports it. So removed it.

- Also removed `psutil` dependency as the sole thing we were using from there is `psutil.cpu_count()`. But now `multiprocessing` already supports it.

- Otherwise, removed a few unused stuff.

I tested the updates successfully on ERIS cluster.