### PR TITLE
Remove dependency on GPUtil

### DIFF
--- a/scripts/fsl_eddy.py
+++ b/scripts/fsl_eddy.py
@@ -92,8 +92,8 @@ class Eddy(cli.Application):
                 nvcc['--version'] & FG
                 
                 print('\nCUDA found, looking for available GPU\n')
-                from GPUtil import getFirstAvailable
-                getFirstAvailable()
+                from plumbum.cmd import nvidia_smi
+                nvidia_smi['-L'] & FG
                 
                 print('available GPU found, looking for eddy_cuda executable\n'
                       'make sure you have created a softlink according to '

--- a/scripts/fsl_topup_epi_eddy.py
+++ b/scripts/fsl_topup_epi_eddy.py
@@ -139,8 +139,8 @@ class TopupEddyEpi(cli.Application):
                 nvcc['--version'] & FG
 
                 print('\nCUDA found, looking for available GPU\n')
-                from GPUtil import getFirstAvailable
-                getFirstAvailable()
+                from plumbum.cmd import nvidia_smi
+                nvidia_smi['-L'] & FG
 
                 print('available GPU found, looking for eddy_cuda executable\n'
                       'make sure you have created a softlink according to '


### PR DESCRIPTION
Maintaining GPUtil dependency was likely infeasible. We had removed it from CNN brain masking long ago: https://github.com/pnlbwh/CNN-Diffusion-MRIBrain-Segmentation/commit/e929b80c4118b01fc73f1ca71c149efa7fb57c0e

Now we caught the obsolescence in this repository. Hence, I am removing it from here too. Now we do something clever: we utilize `nvidia-smi` command as that will surely be present in any GPU node.